### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-#CHANGELOG
+# CHANGELOG
 ----------------
 
 ## 0.1.0 (09.24.2105) estelle.github.io

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Handles these test cases:
 
 ## Exceptions
 
-####Complex Regular Expressions
+#### Complex Regular Expressions
 If the digits allowed by your regular expression are constrained or complicated, such as months only allowing 01-12, include a made up `data-valid-example` attribute that takes as its value a **valid** value that would match the pattern.
 
 ```html


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
